### PR TITLE
Changing the master/slave language

### DIFF
--- a/product/migrations/0043_auto_20160505_1033.py
+++ b/product/migrations/0043_auto_20160505_1033.py
@@ -18,8 +18,8 @@ class Migration(migrations.Migration):
             name='UserFollowMapping',
             fields=[
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('master', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='followermapping', to=settings.AUTH_USER_MODEL)),
-                ('slave', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='followingmapping', to=settings.AUTH_USER_MODEL)),
+                ('main', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='followermapping', to=settings.AUTH_USER_MODEL)),
+                ('subordinate', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='followingmapping', to=settings.AUTH_USER_MODEL)),
             ],
         ),
         migrations.AddField(

--- a/product/models.py
+++ b/product/models.py
@@ -126,8 +126,8 @@ class MyUserManager(BaseUserManager):
         return user
 
 class UserFollowMapping(models.Model): 
-    master = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete = models.CASCADE, related_name = "followermapping")
-    slave = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete = models.CASCADE, related_name = "followingmapping")
+    main = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete = models.CASCADE, related_name = "followermapping")
+    subordinate = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete = models.CASCADE, related_name = "followingmapping")
 
 
 class MyUser(AbstractBaseUser):

--- a/product/views.py
+++ b/product/views.py
@@ -45,7 +45,7 @@ class FollowUser(APIView):
             data = {"error":"用户不存在"}
             return Response(data,status=400)
 
-        UserFollowMapping.objects.create(master=user,slave=request.user)
+        UserFollowMapping.objects.create(main=user,subordinate=request.user)
         return Response({},status=200)
 
 class UnfollowUser(APIView):
@@ -60,7 +60,7 @@ class UnfollowUser(APIView):
             data = {"error":"用户不存在"}
             return Response(data,status=400)
         try:
-            map = UserFollowMapping.objects.get(master=user,slave=request.user)
+            map = UserFollowMapping.objects.get(main=user,subordinate=request.user)
         except:
             data = {"error":"未关注该用户"}
             return Response(data,status=400)


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.